### PR TITLE
update to work with react-native >0.26

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
-var React = require('react-native');
+import React from 'react';
+import { Text } from 'react-native';
+
 var nodeEmoji = require('node-emoji');
 
 class Emoji extends React.Component {
   render() {
     var emoji = nodeEmoji.get(this.props.name);
-    return (<React.Text>{emoji}</React.Text>);
+    return (<Text>{emoji}</Text>);
   }
 }
 


### PR DESCRIPTION
Support for breaking change: React API must be now required from react package (previously a warning on 0.25)
