### PR TITLE
Pass props to underlying <Text />

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ class Emoji extends React.Component {
 
   render() {
     const emoji = nodeEmoji.get(this.props.name);
-    return (<Text>{ emoji }</Text>);
+    return (<Text {...this.props}>{ emoji }</Text>);
   }
 }
 


### PR DESCRIPTION
This allows us to pass accessibility props like `allowFontScaling={false}` to the emojis as well (as now they don't honor the allowFontScaling prop of the parent/wrapper <Text /> for example).